### PR TITLE
react: Bump version of csstype used

### DIFF
--- a/types/react/package.json
+++ b/types/react/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "csstype": "^2.2.0"
+    "csstype": "^2.5.7"
   }
 }


### PR DESCRIPTION
The old version of csstype appears to be the cause of this error for us: 
```
 Type ‘“inline”’ is not assignable to type ‘ResizeProperty’.
```

From MDN, we can see that `"inline"` is in fact a valid property for `resize`, and I've verified that the latest version of `csstype` includes `"inline"` in the union type `ResizeProperty`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/frenic/csstype/blob/master/index.d.ts (search for the definition of `ResizeProperties` in the raw file)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

